### PR TITLE
docs: remove TypeScript acknowledgement from README.md  The project R…

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,9 +340,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## Acknowledgments
 Babel for AST parsing
-TypeScript for type analysis
 glob for file discovery
-
 
 
 


### PR DESCRIPTION
…EADME previously thanked the TypeScript team— that reference is no longer relevant and has been removed to keep the documentation focused.  Co-authored-by: Aman-s12345 <amansinghbiuri@example.com>